### PR TITLE
Fixed typo for -ha

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Then deploy the helm chart such as below:
 
 Artifactory ⎈:
 ```text
-helm upgrade --install artifactory-ha  jfrog/artifactory-ha \
+helm upgrade --install artifactory  jfrog/artifactory \
        --set artifactory.masterKey=FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF \
        --set artifactory.joinKey=EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE \
        -f helm/artifactory-values.yaml


### PR DESCRIPTION
Changed the image from artifactory-ha to artifactory for non ha deployment.